### PR TITLE
Add support for Java packages

### DIFF
--- a/repomate_junit4/junit4.py
+++ b/repomate_junit4/junit4.py
@@ -318,11 +318,15 @@ class JUnit4Hooks(plug.Plugin):
             lambda t: not self._is_abstract_class(t), test_classes
         )
         for test_class in concrete_test_classes:
+            package_prefix = self._extract_package_prefix(test_class)
             prod_class_name = test_class.name.replace("Test.java", ".java")
             try:
-                prod_class_path = list(
-                    filter(lambda file: file.name == prod_class_name, java_files)
-                )[0]
+                prod_class_path = [
+                    file
+                    for file in java_files
+                    if file.name == prod_class_name
+                    and self._extract_package_prefix(file) == package_prefix
+                ][0]
                 adjacent_java_files = [
                     file
                     for file in prod_class_path.parent.glob("*.java")
@@ -338,7 +342,7 @@ class JUnit4Hooks(plug.Plugin):
                     plug.HookResult(
                         SECTION,
                         Status.ERROR,
-                        "no production class found for {}".format(test_class.name),
+                        "no production class found for {}{}".format(package_prefix, test_class.name),
                     )
                 )
 
@@ -367,6 +371,24 @@ class JUnit4Hooks(plug.Plugin):
                 succeeded.append(plug.HookResult(SECTION, status, msg))
         return succeeded, failed
 
+    @staticmethod
+    def _extract_package_prefix(test_class: pathlib.Path) -> str:
+        """Return the package this test class is in, with a trailing dot. An
+        empty string (no trailing dot) denotes the default package.
+        """
+        assert test_class.name.endswith(".java")
+        # yes, $ is a valid character for a Java identifier ...
+        ident = r"[\w$][\w\d_$]*"
+        regex = r"^\s*?package\s+({ident}(.{ident})*);".format(ident=ident)
+        matches = re.search(
+            regex,
+            test_class.read_text(encoding=sys.getdefaultencoding()),
+            flags=re.MULTILINE,
+        )
+        if matches:
+            return matches.group(1) + "."
+        return ""
+
     def _is_abstract_class(self, test_class: pathlib.Path) -> bool:
         """Check if the file is an abstract class."""
         assert test_class.name.endswith(".java")
@@ -378,10 +400,10 @@ class JUnit4Hooks(plug.Plugin):
         )
         return match is not None
 
-    def _generate_classpath(self, *java_files: pathlib.Path) -> str:
+    def _generate_classpath(self, *paths: pathlib.Path) -> str:
         """
         Args:
-            java_files: One or more paths to java files.
+            paths: One or more paths to add to the classpath.
         Returns:
             a formated classpath to be used with ``java`` and ``javac``
         """
@@ -390,8 +412,8 @@ class JUnit4Hooks(plug.Plugin):
             "This will probably crash."
         )
         classpath = self._classpath
-        for file in java_files:
-            classpath += ":{.parent!s}".format(file)
+        for path in paths:
+            classpath += ":{!s}".format(path)
 
         if not (self._hamcrest_path or HAMCREST_JAR in classpath):
             LOGGER.warning(warn.format(HAMCREST_JAR))
@@ -406,10 +428,38 @@ class JUnit4Hooks(plug.Plugin):
         return classpath
 
     def _junit(self, test_class, prod_class):
-        classpath = self._generate_classpath(
-            *test_class.parent.glob("*.java"), prod_class
+        package_prefix = self._extract_package_prefix(test_class)
+        prod_package_prefix = self._extract_package_prefix(prod_class)
+        if package_prefix != prod_package_prefix:
+            msg = (
+                "Test class {} has package {}, but production class {} has package {}"
+            ).format(
+                test_class.name, package_prefix, prod_class.name, prod_package_prefix
+            )
+            raise _ActException(plug.HookResult(SECTION, Status.ERROR, msg))
+
+        prod_class_dir = prod_class.parent
+        test_class_dir = test_class.parent
+
+        required_dir_structure = package_prefix.replace(".", os.path.sep).rstrip(
+            os.path.sep
         )
+        if not str(prod_class_dir).endswith(required_dir_structure):
+            msg = "Student directory structure does not conform to package statement"
+            raise _ActException(plug.HookResult(SECTION, Status.ERROR, msg))
+        if not str(test_class_dir).endswith(required_dir_structure):
+            msg = "Reference directory structure does not conform to package statement"
+            raise _ActException(plug.HookResult(SECTION, Status.ERROR, msg))
+
+        for _ in range(package_prefix.count(".")):
+            prod_class_dir = prod_class_dir.parent
+            test_class_dir = test_class_dir.parent
+
+        classpath = self._generate_classpath(test_class_dir, prod_class_dir)
         test_class_name = test_class.name[: -len(test_class.suffix)]  # remove .java
+        if package_prefix:
+            test_class_name = package_prefix + test_class_name
+
         command = [
             "java",
             "-cp",

--- a/tests/reference-tests/multiple-packages/FiboTest.java
+++ b/tests/reference-tests/multiple-packages/FiboTest.java
@@ -1,0 +1,33 @@
+import org.junit.Test;
+import org.junit.Before;
+import static org.junit.Assert.*;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.CoreMatchers.*;
+
+public class FiboTest {
+    @Test
+    public void correctlyGeneratesFirst10Numbers() {
+        Fibo f = new Fibo();
+        long[] expected = {0, 1, 1, 2, 3, 5, 8, 13, 21, 34};
+        long[] actual = new long[10];
+
+        for (int i = 0; i < 10; i++) {
+            actual[i] = f.next();
+        }
+
+        assertThat(actual, equalTo(expected));
+    }
+
+    @Test
+    public void correctlyGeneratesFiftiethNumber() {
+        // note that the first number is counted as the 0th
+        Fibo f = new Fibo();
+
+        for (int i = 0; i < 50; i++) {
+            f.next();
+        }
+
+        assertThat(f.next(), equalTo(12586269025l));
+    }
+}

--- a/tests/reference-tests/multiple-packages/com/repomate/fibo/FiboTest.java
+++ b/tests/reference-tests/multiple-packages/com/repomate/fibo/FiboTest.java
@@ -1,0 +1,34 @@
+package com.repomate.fibo;
+import org.junit.Test;
+import org.junit.Before;
+import static org.junit.Assert.*;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.CoreMatchers.*;
+
+public class FiboTest {
+    @Test
+    public void correctlyGeneratesFirst10Numbers() {
+        Fibo f = new Fibo();
+        long[] expected = {0, 1, 1, 2, 3, 5, 8, 13, 21, 34};
+        long[] actual = new long[10];
+
+        for (int i = 0; i < 10; i++) {
+            actual[i] = f.next();
+        }
+
+        assertThat(actual, equalTo(expected));
+    }
+
+    @Test
+    public void correctlyGeneratesFiftiethNumber() {
+        // note that the first number is counted as the 0th
+        Fibo f = new Fibo();
+
+        for (int i = 0; i < 50; i++) {
+            f.next();
+        }
+
+        assertThat(f.next(), equalTo(12586269025l));
+    }
+}

--- a/tests/reference-tests/multiple-packages/se/repomate/fibo/FiboTest.java
+++ b/tests/reference-tests/multiple-packages/se/repomate/fibo/FiboTest.java
@@ -1,0 +1,34 @@
+package se.repomate.fibo;
+import org.junit.Test;
+import org.junit.Before;
+import static org.junit.Assert.*;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.CoreMatchers.*;
+
+public class FiboTest {
+    @Test
+    public void correctlyGeneratesFirst10Numbers() {
+        Fibo f = new Fibo();
+        long[] expected = {0, 1, 1, 2, 3, 5, 8, 13, 21, 34};
+        long[] actual = new long[10];
+
+        for (int i = 0; i < 10; i++) {
+            actual[i] = f.next();
+        }
+
+        assertThat(actual, equalTo(expected));
+    }
+
+    @Test
+    public void correctlyGeneratesFiftiethNumber() {
+        // note that the first number is counted as the 0th
+        Fibo f = new Fibo();
+
+        for (int i = 0; i < 50; i++) {
+            f.next();
+        }
+
+        assertThat(f.next(), equalTo(12586269025l));
+    }
+}

--- a/tests/reference-tests/packaged-code/se/repomate/fibo/FiboTest.java
+++ b/tests/reference-tests/packaged-code/se/repomate/fibo/FiboTest.java
@@ -1,0 +1,34 @@
+package se.repomate.fibo;
+import org.junit.Test;
+import org.junit.Before;
+import static org.junit.Assert.*;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.CoreMatchers.*;
+
+public class FiboTest {
+    @Test
+    public void correctlyGeneratesFirst10Numbers() {
+        Fibo f = new Fibo();
+        long[] expected = {0, 1, 1, 2, 3, 5, 8, 13, 21, 34};
+        long[] actual = new long[10];
+
+        for (int i = 0; i < 10; i++) {
+            actual[i] = f.next();
+        }
+
+        assertThat(actual, equalTo(expected));
+    }
+
+    @Test
+    public void correctlyGeneratesFiftiethNumber() {
+        // note that the first number is counted as the 0th
+        Fibo f = new Fibo();
+
+        for (int i = 0; i < 50; i++) {
+            f.next();
+        }
+
+        assertThat(f.next(), equalTo(12586269025l));
+    }
+}

--- a/tests/repos/default-packaged-code/README.md
+++ b/tests/repos/default-packaged-code/README.md
@@ -1,0 +1,2 @@
+This repo should use the `se.repomate.fibo` package, but uses the default
+package.

--- a/tests/repos/default-packaged-code/src/Fibo.java
+++ b/tests/repos/default-packaged-code/src/Fibo.java
@@ -1,0 +1,23 @@
+/**
+ * Class for calculating Fibonacci numbers.
+ */
+
+public class Fibo {
+    private long prev;
+    private long current;
+
+    public Fibo() {
+        prev = 0;
+        current = 1;
+    }
+
+    /**
+     * Generate the next Fibonacci number.
+     */
+    public long next() {
+        long ret = prev;
+        prev = current;
+        current = ret + current;
+        return ret;
+    }
+}

--- a/tests/repos/no-dir-structure-packaged-code/README.md
+++ b/tests/repos/no-dir-structure-packaged-code/README.md
@@ -1,0 +1,2 @@
+This repo has a a package statment in `src/Fibo.java`, but there is no
+corresponding directory structure.

--- a/tests/repos/student-multiple-packages/README.md
+++ b/tests/repos/student-multiple-packages/README.md
@@ -1,0 +1,2 @@
+Repo with several different packages, all correctly packaged with correct
+implementations.

--- a/tests/repos/student-multiple-packages/src/Fibo.java
+++ b/tests/repos/student-multiple-packages/src/Fibo.java
@@ -1,0 +1,23 @@
+/**
+ * Class for calculating Fibonacci numbers.
+ */
+
+public class Fibo {
+    private long prev;
+    private long current;
+
+    public Fibo() {
+        prev = 0;
+        current = 1;
+    }
+
+    /**
+     * Generate the next Fibonacci number.
+     */
+    public long next() {
+        long ret = prev;
+        prev = current;
+        current = ret + current;
+        return ret;
+    }
+}

--- a/tests/repos/student-multiple-packages/src/com/repomate/fibo/Fibo.java
+++ b/tests/repos/student-multiple-packages/src/com/repomate/fibo/Fibo.java
@@ -1,0 +1,24 @@
+package com.repomate.fibo;
+/**
+ * Class for calculating Fibonacci numbers.
+ */
+
+public class Fibo {
+    private long prev;
+    private long current;
+
+    public Fibo() {
+        prev = 0;
+        current = 1;
+    }
+
+    /**
+     * Generate the next Fibonacci number.
+     */
+    public long next() {
+        long ret = prev;
+        prev = current;
+        current = ret + current;
+        return ret;
+    }
+}

--- a/tests/repos/student-multiple-packages/src/se/repomate/fibo/Fibo.java
+++ b/tests/repos/student-multiple-packages/src/se/repomate/fibo/Fibo.java
@@ -1,0 +1,24 @@
+package se.repomate.fibo;
+/**
+ * Class for calculating Fibonacci numbers.
+ */
+
+public class Fibo {
+    private long prev;
+    private long current;
+
+    public Fibo() {
+        prev = 0;
+        current = 1;
+    }
+
+    /**
+     * Generate the next Fibonacci number.
+     */
+    public long next() {
+        long ret = prev;
+        prev = current;
+        current = ret + current;
+        return ret;
+    }
+}

--- a/tests/repos/student-packaged-code/README.md
+++ b/tests/repos/student-packaged-code/README.md
@@ -1,0 +1,2 @@
+# Packaged code
+This repo is for testing the support for packaged Java code.

--- a/tests/repos/student-packaged-code/src/se/repomate/fibo/Fibo.java
+++ b/tests/repos/student-packaged-code/src/se/repomate/fibo/Fibo.java
@@ -1,0 +1,24 @@
+package se.repomate.fibo;
+/**
+ * Class for calculating Fibonacci numbers.
+ */
+
+public class Fibo {
+    private long prev;
+    private long current;
+
+    public Fibo() {
+        prev = 0;
+        current = 1;
+    }
+
+    /**
+     * Generate the next Fibonacci number.
+     */
+    public long next() {
+        long ret = prev;
+        prev = current;
+        current = ret + current;
+        return ret;
+    }
+}

--- a/tests/test_junit4.py
+++ b/tests/test_junit4.py
@@ -45,7 +45,15 @@ Args.__new__.__defaults__ = (None,) * len(Args._fields)
 CUR_DIR = pathlib.Path(__file__).parent
 REPO_DIR = CUR_DIR / "repos"
 
-MASTER_REPO_NAMES = ("week-10", "week-11", "week-12", "week-13", "week-14")
+MASTER_REPO_NAMES = (
+    "week-10",
+    "week-11",
+    "week-12",
+    "week-13",
+    "week-14",
+    "packaged-code",
+    "multiple-packages",
+)
 
 SUCCESS_REPO = REPO_DIR / "some-student-week-10"
 FAIL_REPO = REPO_DIR / "other-student-week-11"
@@ -55,6 +63,10 @@ NO_MASTER_MATCH_REPO = REPO_DIR / "some-student-week-nope"
 COMPILE_ERROR_REPO = REPO_DIR / "compile-error-week-10"
 DIR_PATHS_WITH_SPACES = REPO_DIR / "space-week-10"
 ABSTRACT_TEST_REPO = REPO_DIR / "student-week-14"
+PACKAGED_CODE_REPO = REPO_DIR / "student-packaged-code"
+DEFAULT_PACKAGED_CODE_REPO = REPO_DIR / "default-packaged-code"
+NO_DIR_STRUCTURE_REPO = REPO_DIR / "no-dir-structure-packaged-code"
+MULTIPLE_PACKAGES_REPO = REPO_DIR / "student-multiple-packages"
 
 assert SUCCESS_REPO.exists(), "test pre-requisite error, dir must exist"
 assert FAIL_REPO.exists(), "test pre-requisite error, dir must exist"
@@ -276,6 +288,30 @@ Expected: is <false>
 
     def test_runs_correctly_when_paths_include_whitespace(self, hooks):
         result = hooks.act_on_cloned_repo(DIR_PATHS_WITH_SPACES)
+
+        assert result.status == Status.SUCCESS
+
+    def test_runs_with_packaged_code(self, hooks):
+        """Test that packaged code is handled correctly."""
+        result = hooks.act_on_cloned_repo(PACKAGED_CODE_REPO)
+
+        assert result.status == Status.SUCCESS
+        assert "Test class se.repomate.fibo.FiboTest passed!" in str(result.msg)
+
+    def test_error_when_student_code_is_incorrectly_packaged(self, hooks):
+        """Test that a test class expecting a package errors out when the
+        directory structure in the student repo does not correspond to the
+        package statement in the test class.
+        """
+        result = hooks.act_on_cloned_repo(NO_DIR_STRUCTURE_REPO)
+
+        assert result.status == Status.ERROR
+
+    def test_runs_with_multiple_packages(self, hooks):
+        """Test that a reference test suite with several packages is run
+        correctly.
+        """
+        result = hooks.act_on_cloned_repo(MULTIPLE_PACKAGES_REPO)
 
         assert result.status == Status.SUCCESS
 


### PR DESCRIPTION
Adds support for Java packages (multiple packages per repo is supported!). That is to say, the reference test class may now have a package statement. The reference test class and production class must both have the same package statements, and directory structures must correctly mirror the package statement. As long as the fully qualified names are different, this also allows for duplicate class names. For example, there can be a `Main.java` in the default package, and an `se/repomate/Main.java` in the `se.repomate` package, and they won't clash during production class lookup.

Fix #15 